### PR TITLE
Add nginx config and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ Place these files in a `models/` folder or project root:
 
 
 ---
+## Deployment with Nginx
+1. Install Nginx:
+```bash
+sudo apt update && sudo apt install nginx
+```
+
+2. Copy the configuration and generate a self-signed certificate:
+```bash
+sudo cp nginx/fastapi.conf /etc/nginx/conf.d/
+sudo mkdir -p /etc/nginx/ssl
+sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/ssl/selfsigned.key -out /etc/nginx/ssl/selfsigned.crt
+```
+For production, use Let's Encrypt instead:
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d your-domain
+```
+
+3. Start the application servers:
+```bash
+uvicorn backend.main:app --host 0.0.0.0 --port 8000
+streamlit run frontend/app.py --server.port 8501
+```
+
+4. Reload Nginx:
+```bash
+sudo nginx -s reload
+```
+
+Requests to https://<host>/api will reach FastAPI and / will display the Streamlit UI.
 
 
 ## 📜 License

--- a/nginx/fastapi.conf
+++ b/nginx/fastapi.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    # Redirect all HTTP traffic to HTTPS
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name localhost;
+
+    # Self-signed certificate for development
+    ssl_certificate     /etc/nginx/ssl/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/ssl/selfsigned.key;
+    # For production with Let's Encrypt, replace the above paths with the
+    # certificates obtained via certbot.
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # Proxy API calls to FastAPI
+    location /api/ {
+        proxy_pass http://localhost:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Proxy everything else to Streamlit
+    location / {
+        proxy_pass http://localhost:8501/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary
- add `nginx/fastapi.conf` with reverse proxy and security headers
- document Nginx deployment steps with SSL in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684af3bf7b248330907c768448f77b87